### PR TITLE
Auto get access token if refresh token available

### DIFF
--- a/SpotifyPlugin.cs
+++ b/SpotifyPlugin.cs
@@ -428,7 +428,10 @@ namespace Flow.Launcher.Plugin.SpotifyPremium
         private async Task ReconnectAsync()
         {
             if (authSemaphore.CurrentCount == 0)
+            {
+                await authSemaphore.WaitAsync();
                 return;
+            }
             await authSemaphore.WaitAsync();
             await _client.ConnectWebClient();
             currentUserId = await _client.GetUserIdAsync();

--- a/SpotifyPlugin.cs
+++ b/SpotifyPlugin.cs
@@ -430,6 +430,7 @@ namespace Flow.Launcher.Plugin.SpotifyPremium
             if (authSemaphore.CurrentCount == 0)
             {
                 await authSemaphore.WaitAsync();
+                authSemaphore.Release();
                 return;
             }
             await authSemaphore.WaitAsync();

--- a/SpotifyPlugin.cs
+++ b/SpotifyPlugin.cs
@@ -106,6 +106,9 @@ namespace Flow.Launcher.Plugin.SpotifyPremium
                 await ReconnectAsync();
             }
 
+            if (token.IsCancellationRequested)
+                return null;
+
             try
             {
                 List<Result> results;
@@ -424,8 +427,12 @@ namespace Flow.Launcher.Plugin.SpotifyPremium
 
         private async Task ReconnectAsync()
         {
+            if (authSemaphore.CurrentCount == 0)
+                return;
+            await authSemaphore.WaitAsync();
             await _client.ConnectWebClient();
             currentUserId = await _client.GetUserIdAsync();
+            authSemaphore.Release();
         }
 
         //Return a generic reconnection action

--- a/SpotifyPluginClient.cs
+++ b/SpotifyPluginClient.cs
@@ -101,22 +101,18 @@ namespace Flow.Launcher.Plugin.SpotifyPremium
 
         public bool ApiConnected => _spotifyClient != null;
 
-        public bool TokenValid
+        public async Task<bool> CheckTokenValidityAsync()
         {
-            get
+            //Hit a lightweight endpoint to see if the current token is still valid
+            try
             {
-                //Hit a lightweight endpoint to see if the current token is still valid
-                try
-                {
-                    var prof = _spotifyClient.UserProfile.Current().GetAwaiter().GetResult();
-                    return true;
+                var prof = await _spotifyClient.UserProfile.Current();
+                return true;
 
-                }
-                catch (APIUnauthorizedException e)
-                {
-                    return false;
-                }
-
+            }
+            catch (APIUnauthorizedException e)
+            {
+                return false;
             }
         }
 
@@ -222,7 +218,12 @@ namespace Flow.Launcher.Plugin.SpotifyPremium
         {
             var shuffleRequest = new PlayerShuffleRequest(!ShuffleStatus);
             _spotifyClient.Player.SetShuffle(shuffleRequest).GetAwaiter().GetResult();
-            ;
+        }
+
+        public bool RefreshTokenAvailable()
+        {
+            _securityStore = SecurityStore.Load(pluginDirectory);
+            return _securityStore.HasRefreshToken;
         }
 
         public async Task ConnectWebClient(bool keepRefreshToken = true)
@@ -295,9 +296,7 @@ namespace Flow.Launcher.Plugin.SpotifyPremium
                 {
                     Console.WriteLine("Unable to open URL, manually open: {0}", uri);
                 }
-                ;
             }
-            ;
 
         }
 


### PR DESCRIPTION
I don't think it's necessary to let user to select to reauthorize if refresh token is available. If refresh token is available (even though invalid), it means user has already done at least one authorization, so auto authorization should be fine. 

I reverse back the SetClient await in Action because if that takes too long, flow will be completely irresponsible. Until we have async Action, we should just let it run without caring its return value.