### PR TITLE
Add refresh music info after action

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -5,7 +5,6 @@ on:
   push:
     branches-ignore:
       - master
-  pull_request:
 
 jobs:
   build:
@@ -15,11 +14,11 @@ jobs:
     - name: Setup .NET
       uses: actions/setup-dotnet@v1
       with:
-        dotnet-version: 3.1.301
+        dotnet-version: 5.0.x
     - name: Restore dependencies
       run: dotnet restore
     - name: Build
-      run: dotnet build --no-restore --framework netcoreapp3.1 -c Release
+      run: dotnet build --no-restore -c Release
     - name: Upload Artifact
       uses: actions/upload-artifact@v2
       with:

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -1,0 +1,26 @@
+name: build
+
+on:
+  push:
+  pull_request:
+
+jobs:
+  build:
+
+    runs-on: windows-latest
+
+    steps:
+    - uses: actions/checkout@v2
+    - name: Setup .NET
+      uses: actions/setup-dotnet@v1
+      with:
+        dotnet-version: 3.1.301
+    - name: Restore dependencies
+      run: dotnet restore
+    - name: Build
+      run: dotnet build --no-restore -c Release
+    - name: Upload Artifact
+      uses: actions/upload-artifact@v2
+      with:
+        name: SpotifyPremium
+        path: Output/Release/

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -1,14 +1,15 @@
 name: build
 
 on:
+  workflow_dispatch:
   push:
+    branches-ignore:
+      - master
   pull_request:
 
 jobs:
   build:
-
     runs-on: windows-latest
-
     steps:
     - uses: actions/checkout@v2
     - name: Setup .NET
@@ -18,7 +19,7 @@ jobs:
     - name: Restore dependencies
       run: dotnet restore
     - name: Build
-      run: dotnet build --no-restore -c Release
+      run: dotnet build --no-restore --framework netcoreapp3.1 -c Release
     - name: Upload Artifact
       uses: actions/upload-artifact@v2
       with:

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -2,10 +2,6 @@ name: Publish Release
 
 on:
   workflow_dispatch:
-  push:
-    branches: [ master ]
-    paths-ignore: 
-      - .github/workflows/*
 
 jobs:
   publish:
@@ -15,7 +11,7 @@ jobs:
       - name: Setup .NET
         uses: actions/setup-dotnet@v1
         with:
-          dotnet-version: 3.1.301
+          dotnet-version: 5.0.x
       - name: get version
         id: version
         uses: notiz-dev/github-action-json-property@release
@@ -25,13 +21,13 @@ jobs:
       - run: echo ${{steps.version.outputs.prop}} 
       - name: Build
         run: |
-          dotnet publish 'Flow.Launcher.Plugin.SpotifyPremium.csproj' --framework netcoreapp3.1  -c Release -o "SpotifyPremium"
-          7z a -tzip "Flow.Launcher.Plugin.SpotifyPremium.zip" "SpotifyPremium/*"
-          rm -r "SpotifyPremium"
+          dotnet publish 'Flow.Launcher.Plugin.SpotifyPremium.csproj' -r win-x64 -c Release -o "SpotifyPremium-${{steps.version.outputs.prop}}"
+          7z a -tzip "SpotifyPremium-${{steps.version.outputs.prop}}.zip" "./SpotifyPremium-${{steps.version.outputs.prop}}/*"
+          rm -r "SpotifyPremium-${{steps.version.outputs.prop}}"
       - name: Publish
         uses: softprops/action-gh-release@v1
         with:
-          files: "Flow.Launcher.Plugin.SpotifyPremium.zip"
+          files: "SpotifyPremium-${{steps.version.outputs.prop}}"
           tag_name: "v${{steps.version.outputs.prop}}"
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/SpotifyPlugin.cs
+++ b/SpotifyPlugin.cs
@@ -1,4 +1,4 @@
-using Flow.Launcher.Plugin;
+﻿using Flow.Launcher.Plugin;
 using System;
 using System.Collections.Generic;
 using System.Linq;
@@ -213,48 +213,28 @@ namespace Flow.Launcher.Plugin.SpotifyPremium
 
             return new List<Result>()
             {
-                new()
-                {
-                    Title = t?.Name ?? e?.Name ?? "Not Available",
-                    SubTitle = $"{status} | by {string.Join(", ", t.Artists.Select(a => String.Join("", a.Name)))}",
-                    IcoPath = (icon != null ? icon.Result : SpotifyIcon)
-                },
-                new()
-                {
-                    IcoPath = SpotifyIcon,
-                    Title = "Pause / Resume",
-                    SubTitle = $"{toggleAction}: {t.Name}",
-                    Action = _ =>
-                    {
-                        if (playbackContext.IsPlaying)
-                            _client.Pause();
-                        else
-                            _client.Play();
-                        return true;
-                    }
-                },
-                new()
-                {
-                    IcoPath = SpotifyIcon,
-                    Title = "Next",
-                    SubTitle = $"Skip: {t.Name}",
-                    Action = context =>
-                    {
-                        _client.Skip();
-                        return true;
-                    }
-                },
-                new()
-                {
-                    IcoPath = SpotifyIcon,
-                    Title = "Last",
-                    SubTitle = "Skip backwards",
-                    Action = context =>
-                    {
-                        _client.SkipBack();
-                        return true;
-                    }
-                },
+                SingleResult(
+                    t?.Name ?? e?.Name ?? "Not Available",
+                    $"{status} | by {string.Join(", ", t.Artists.Select(a => String.Join("", a.Name)))}",
+                    icon != null ? icon.Result : SpotifyIcon),
+                SingleResult(
+                    "Pause / Resume",
+                    $"{toggleAction}: {t.Name}",
+                    action: () =>
+                        {
+                            if (playbackContext.IsPlaying)
+                            {
+                                _client.Pause();
+                            }
+                            else
+                            {
+                                _client.Play();
+                            }
+
+                        }, 
+                    hideAfterAction: true),
+                PlayNext(rawQuery).First(),
+                PlayLast(rawQuery).First(),
                 ToggleMute().First(),
                 ToggleShuffle().First(),
                 SetVolume().First()

--- a/SpotifyPlugin.cs
+++ b/SpotifyPlugin.cs
@@ -68,31 +68,31 @@ namespace Flow.Launcher.Plugin.SpotifyPremium
 
             //view query count and average query duration
             _terms.Add("diag", q =>
-                new List<Result> {
-                    SingleResult($"Query Count: {context.CurrentPluginMetadata.QueryCount}",
+                SingleResultInList(
+                    $"Query Count: {context.CurrentPluginMetadata.QueryCount}",
                     $"Avg. Query Time: {context.CurrentPluginMetadata.AvgQueryTime}ms",
-                    action: null)
-                });
+                    action: null));
 
             _terms.Add("reconnect", q =>
-                new List<Result> {
-                    SingleResult("Reconnect", "Force a reconnection and remove the refresh token", action: ReconnectAction(_client, false))
-                });
+                SingleResultInList(
+                    "Reconnect",
+                    "Force a reconnection and remove the refresh token",
+                    action: ReconnectAction(_client, false)));
 
             return Task.CompletedTask;
         }
 
         private List<Result> Play(string arg) =>
-            new List<Result> { SingleResult("Play", $"Resume: {_client.CurrentPlaybackName}", action: _client.Play) };
+            SingleResultInList("Play", $"Resume: {_client.CurrentPlaybackName}", action: _client.Play);
 
         private List<Result> Pause(string arg = null) =>
-            new List<Result> { SingleResult("Pause", $"Pause: {_client.CurrentPlaybackName}", action: _client.Pause) };
+            SingleResultInList("Pause", $"Pause: {_client.CurrentPlaybackName}", action: _client.Pause);
 
         private List<Result> PlayNext(string arg) =>
-            new List<Result> { SingleResult("Next", $"Skip: {_client.CurrentPlaybackName}", action: _client.Skip) };
+            SingleResultInList("Next", $"Skip: {_client.CurrentPlaybackName}", action: _client.Skip);
 
         private List<Result> PlayLast(string arg) =>
-            new List<Result> { SingleResult("Last", "Skip Backwards", action: _client.SkipBack) };
+            SingleResultInList("Last", "Skip Backwards", action: _client.SkipBack);
 
         public async Task<List<Result>> QueryAsync(Query query, CancellationToken token)
         {
@@ -101,12 +101,10 @@ namespace Flow.Launcher.Plugin.SpotifyPremium
 
             if (!_client.RefreshTokenAvailable())
             {
-                return new List<Result> {
-                    SingleResult(
-                        "Require Authentication", "Select to authorize",
-                        action: ReconnectAction(_client),
-                        hideAfterAction: false)
-                };
+                return SingleResultInList(
+                    "Require Authentication", "Select to authorize",
+                    action: ReconnectAction(_client),
+                    hideAfterAction: false);
             }
             
             if (!_client.ApiConnected)
@@ -121,13 +119,11 @@ namespace Flow.Launcher.Plugin.SpotifyPremium
 
             if (!await _client.UserHasSpotifyPremium())
             {
-                return new List<Result> {
-                    SingleResult(
-                        "Current Spotify account is not premium!",
-                        "Switch to premium account, then select this to use new login",
-                        action: ReconnectAction(_client, false),
-                        hideAfterAction: false)
-                };
+                return SingleResultInList(
+                    "Current Spotify account is not premium!",
+                    "Switch to premium account, then select this to use new login",
+                    action: ReconnectAction(_client, false),
+                    hideAfterAction: false);
             }
 
             if (token.IsCancellationRequested)
@@ -174,12 +170,9 @@ namespace Flow.Launcher.Plugin.SpotifyPremium
             catch (Exception e)
             {
                 Console.WriteLine(e);
-                return new List<Result>
-                {
-                    SingleResult(
+                return SingleResultInList(
                     "There was an error with your request",
-                    e.GetBaseException().Message)
-                };
+                    e.GetBaseException().Message);
             }
         }
 
@@ -189,15 +182,13 @@ namespace Flow.Launcher.Plugin.SpotifyPremium
             if (d == null)
             {
                 //Must have an active device to control Spotify
-                return new List<Result> 
-                {
-                    SingleResult("No active device", "Select device with `sp device`", 
-                        action: () =>
-                            {
-                                _context.API.ChangeQuery($"{_context.CurrentPluginMetadata.ActionKeywords[0]} device");
-                            }, 
-                        hideAfterAction: false)
-                };
+                return SingleResultInList(
+                    "No active device", "Select device with `sp device`", 
+                    action: () =>
+                        {
+                            _context.API.ChangeQuery($"{_context.CurrentPluginMetadata.ActionKeywords[0]} device");
+                        }, 
+                    hideAfterAction: false);
                     
             }
 
@@ -218,11 +209,11 @@ namespace Flow.Launcher.Plugin.SpotifyPremium
 
             return new List<Result>()
             {
-                SingleResult(
+                SingleResultInList(
                     t?.Name ?? e?.Name ?? "Not Available",
                     $"{status} | by {string.Join(", ", t.Artists.Select(a => String.Join("", a.Name)))}",
-                    icon != null ? icon.Result : SpotifyIcon),
-                SingleResult(
+                    icon != null ? icon.Result : SpotifyIcon).First(),
+                SingleResultInList(
                     "Pause / Resume",
                     $"{toggleAction}: {t.Name}",
                     action: () =>
@@ -237,7 +228,7 @@ namespace Flow.Launcher.Plugin.SpotifyPremium
                             }
 
                         },
-                    hideAfterAction: true),
+                    hideAfterAction: true).First(),
                 PlayNext(string.Empty).First(),
                 PlayLast(string.Empty).First(),
                 ToggleMute().First(),
@@ -249,9 +240,7 @@ namespace Flow.Launcher.Plugin.SpotifyPremium
         private List<Result> ToggleMute(string arg = null)
         {
             var toggleAction = _client.MuteStatus ? "Unmute" : "Mute";
-            return new List<Result> {
-                SingleResult("Toggle Mute", $"{toggleAction}: {_client.CurrentPlaybackName}", action: _client.ToggleMute)
-            };
+            return SingleResultInList("Toggle Mute", $"{toggleAction}: {_client.CurrentPlaybackName}", action: _client.ToggleMute);
         }
 
         private struct SetVolAction {
@@ -330,24 +319,22 @@ namespace Flow.Launcher.Plugin.SpotifyPremium
 
             if (volAction.validAction)
             {
-                return new List<Result> {
-                    SingleResult(
-                        $"Set Volume to {volAction.target}",
-                        $"Current Volume: {cachedVolume}",
-                        action: () =>
-                            {
-                                _client.SetVolume(volAction.target);
-                            }
-                    )};
+                return SingleResultInList(
+                    $"Set Volume to {volAction.target}",
+                    $"Current Volume: {cachedVolume}",
+                    action: () =>
+                        {
+                            _client.SetVolume(volAction.target);
+                        });
             }
 
-            return new List<Result> { SingleResult($"Volume", $"Current Volume: {cachedVolume}", action: () => { }) };
+            return SingleResultInList($"Volume", $"Current Volume: {cachedVolume}", action: () => { });
         }
 
         private List<Result> ToggleShuffle(string arg = null)
         {
             var toggleAction = _client.ShuffleStatus ? "Off" : "On";
-            return new List<Result> { SingleResult("Toggle Shuffle", $"Turn Shuffle {toggleAction}", action: _client.ToggleShuffle) };
+            return SingleResultInList("Toggle Shuffle", $"Turn Shuffle {toggleAction}", action: _client.ToggleShuffle);
         }
 
         private async Task<List<Result>> SearchAllAsync(string param)
@@ -356,7 +343,7 @@ namespace Flow.Launcher.Plugin.SpotifyPremium
 
             if (string.IsNullOrWhiteSpace(param))
             {
-                return new List<Result> { SingleResult("sp {any search term}", "Perform a full search on albums, tracks, artists, and playlists.") };
+                return SingleResultInList("sp {any search term}", "Perform a full search on albums, tracks, artists, and playlists.");
             }
 
             // Retrieve data and return the first 20 results
@@ -385,7 +372,7 @@ namespace Flow.Launcher.Plugin.SpotifyPremium
 
             if (string.IsNullOrWhiteSpace(param))
             {
-                return new List<Result> { SingleResult("sp track {track name}", "Search for a single Track to play.") };
+                return SingleResultInList("sp track {track name}", "Search for a single Track to play.");
             }
 
             // Retrieve data and return the first 20 results
@@ -416,7 +403,7 @@ namespace Flow.Launcher.Plugin.SpotifyPremium
 
             if (string.IsNullOrWhiteSpace(param))
             {
-                return new List<Result> { SingleResult("sp album {album name}", "Search for an Album to play.") };
+                return SingleResultInList("sp album {album name}", "Search for an Album to play.");
             }
 
             //Get first page of results
@@ -443,7 +430,7 @@ namespace Flow.Launcher.Plugin.SpotifyPremium
 
             if (string.IsNullOrWhiteSpace(param))
             {
-                return new List<Result> { SingleResult("sp artist {artist name}", "Search for an Artist to play.") };
+                return SingleResultInList("sp artist {artist name}", "Search for an Artist to play.");
             }
 
             //Get first page of results
@@ -496,7 +483,7 @@ namespace Flow.Launcher.Plugin.SpotifyPremium
             //Retrieve all available devices
             var allDevices = await _client.GetDevicesAsync();
             if (allDevices.Count == 0)
-                return new List<Result> { SingleResult("No devices found on Spotify.", "Reconnect to client", action: ReconnectAction(_client)) };
+                return SingleResultInList("No devices found on Spotify.", "Reconnect to client", action: ReconnectAction(_client));
 
             var results = allDevices.Where(device => !device.IsRestricted).Select(x => new Result
             {
@@ -550,17 +537,18 @@ namespace Flow.Launcher.Plugin.SpotifyPremium
         }
 
         private List<Result> AuthenticateResult =>
-            new List<Result> {
-                SingleResult("Authentication required to search the Spotify library", "Click this to authenticate", action: ReconnectAction(_client))
-            };
+            SingleResultInList(
+                "Authentication required to search the Spotify library",
+                "Click this to authenticate",
+                action: ReconnectAction(_client));
 
 
         // Returns a SingleResult if no search results are found
         private List<Result> NothingFoundResult =>
-            new List<Result> { SingleResult("No results found on Spotify.", "Please try refining your search", action: () => { }) };
+            SingleResultInList("No results found on Spotify.", "Please try refining your search", action: () => { });
 
         // Returns a list with a single result
-        private Result SingleResult(
+        private List<Result> SingleResultInList(
             string title,
             string subtitle = "",
             string icoPath = SpotifyIcon,
@@ -568,19 +556,22 @@ namespace Flow.Launcher.Plugin.SpotifyPremium
             bool hideAfterAction = true,
             bool requery = true)
             =>
-            new Result()
+            new List<Result>
             {
-                Title = title,
-                SubTitle = subtitle,
-                IcoPath = icoPath,
-                Action = _ =>
+                new ()
                 {
-                    action?.Invoke();
+                    Title = title,
+                    SubTitle = subtitle,
+                    IcoPath = icoPath,
+                    Action = _ =>
+                    {
+                        action?.Invoke();
 
-                    if (requery)
-                        RefreshDisplayInfo();
-                    
-                    return hideAfterAction;
+                        if (requery)
+                            RefreshDisplayInfo();
+
+                        return hideAfterAction;
+                    }
                 }
             };
 
@@ -590,7 +581,7 @@ namespace Flow.Launcher.Plugin.SpotifyPremium
 
             if (string.IsNullOrWhiteSpace(param))
             {
-                return new List<Result> { SingleResult("sp queue {trackname}", "Search for a track to add it to your play queue.") };
+                return SingleResultInList("sp queue {trackname}", "Search for a track to add it to your play queue.");
             }
 
             var results = await SearchTrack(param, true);

--- a/SpotifyPluginClient.cs
+++ b/SpotifyPluginClient.cs
@@ -237,7 +237,7 @@ namespace Flow.Launcher.Plugin.SpotifyPremium
 
             // New volume percentage can not be retrieved even after fully waiting for the call to finish.
             // This seems to be the right amount of time to manually wait so API can return the updated volume after this call.
-            Thread.Sleep(900);
+            Thread.Sleep(1000);
         }
 
         public void ToggleShuffle()

--- a/SpotifyPluginClient.cs
+++ b/SpotifyPluginClient.cs
@@ -7,6 +7,7 @@ using System.Threading.Tasks;
 using System.Linq;
 using System.Net;
 using static SpotifyAPI.Web.Scopes;
+using System.Threading;
 
 namespace Flow.Launcher.Plugin.SpotifyPremium
 {
@@ -202,7 +203,8 @@ namespace Flow.Launcher.Plugin.SpotifyPremium
 
         public void Skip()
         {
-            _spotifyClient.Player.SkipNext();
+            // This needs to wait for completion otherwise API can not retrieve the new track info immediately after this call.
+            _spotifyClient.Player.SkipNext().Wait();
         }
 
         public void SkipBack()
@@ -226,14 +228,16 @@ namespace Flow.Launcher.Plugin.SpotifyPremium
             }
 
             _spotifyClient.Player.SetVolume(volRequest).GetAwaiter().GetResult();
-            ;
         }
 
         public void SetVolume(int volumePercent = 0)
         {
             var volRequest = new PlayerVolumeRequest(volumePercent);
             _spotifyClient.Player.SetVolume(volRequest).GetAwaiter().GetResult();
-            ;
+
+            // New volume percentage can not be retrieved even after fully waiting for the call to finish.
+            // This seems to be the right amount of time to manually wait so API can return the updated volume after this call.
+            Thread.Sleep(900);
         }
 
         public void ToggleShuffle()

--- a/plugin.json
+++ b/plugin.json
@@ -4,7 +4,7 @@
   "Name": "SpotifyPremium",
   "Description": "Spotify Premium for Flow Launcher",
   "Author": "Frank W. (@fow5040)",
-  "Version": "1.1.3",
+  "Version": "1.1.4",
   "Language": "csharp",
   "Website": "https://github.com/fow5040/Flow.Launcher.Plugin.SpotifyPremium",
   "IcoPath": "icon.png",


### PR DESCRIPTION
Context:
When using Spotify action results like next, back, pause and set volume, the music info is not updated after the action has completed. For example when selecting next track, after the action completes, triggering flow again you still see the old track that was playing.

Changes:
1. Added API re-query call for normal functions (terms, not expensive ones)
2. Needed to use wait on skip track API call so the updated music info can be returned, otherwise Spotify's API may not return the info in time.
3. Added workaround for set volume call to sleep for a certain period, not sure why API is not able to get the updated volume even when set volume call has completed.
4. Changed SingleResult method to SingleResultInList to be more clearer. Was mistakenly thinking the method would just return a single result.
5. Added and updated build and publish actions.

Tested:
1. Correct music info/status is shown by flow after each non-expensive commands
2. Comands `PlayNext`, `PlayLast`, `SetVolume`, `Mute`, `Shuffle`, `Resume/Pause`