### PR TITLE
Version bump

### DIFF
--- a/plugin.json
+++ b/plugin.json
@@ -4,7 +4,7 @@
   "Name": "SpotifyPremium",
   "Description": "Spotify Premium for Flow Launcher",
   "Author": "Frank W. (@fow5040)",
-  "Version": "1.1.4",
+  "Version": "1.1.5",
   "Language": "csharp",
   "Website": "https://github.com/fow5040/Flow.Launcher.Plugin.SpotifyPremium",
   "IcoPath": "icon.png",


### PR DESCRIPTION
Realised your plugin.json version is out of sync with your previous release. Once this is merged can then kick off a GitHub action to release the new changes so no need to upload zip manually.