### PR TITLE
Fix client error due to Spotify API

### DIFF
--- a/plugin.json
+++ b/plugin.json
@@ -4,7 +4,7 @@
   "Name": "SpotifyPremium",
   "Description": "Spotify Premium for Flow Launcher",
   "Author": "Frank W. (@fow5040)",
-  "Version": "1.1.5",
+  "Version": "1.1.6",
   "Language": "csharp",
   "Website": "https://github.com/fow5040/Flow.Launcher.Plugin.SpotifyPremium",
   "IcoPath": "icon.png",


### PR DESCRIPTION
Add handling of the erroneous API response.

Fix https://github.com/fow5040/Flow.Launcher.Plugin.SpotifyPremium/issues/41

Tested all functionalities working and without any uncaught errors.